### PR TITLE
refatora função SaveUser para usar QueryRow e simplificar leitura do ID

### DIFF
--- a/repository/postgres/user/repository.go
+++ b/repository/postgres/user/repository.go
@@ -1,0 +1,7 @@
+package user
+
+import "github.com/jackc/pgx/v5"
+
+type Repository struct {
+	conn pgx.Conn
+}

--- a/repository/postgres/user/save_user.go
+++ b/repository/postgres/user/save_user.go
@@ -1,0 +1,27 @@
+package user
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gasparguilherme/my-repository/domain/entities"
+)
+
+func (r Repository) SaveUser(data entities.User) (int, error) {
+	query := `
+	INSERT INTO users(name, email)
+	VALUES(
+		$1, 
+		$2
+	)
+	RETURNING id;
+	`
+
+	var id int
+	err := r.conn.QueryRow(context.TODO(), query, data.Name, data.Email).Scan(id)
+	if err != nil {
+		return 0, fmt.Errorf("executando query: %w", err)
+
+	}
+	return id, nil
+}


### PR DESCRIPTION
Neste pr eu tive a tarefa de criar uma pasta postgres na camada repository, criei uma struct com o campo pgx.Conn para carregar conexões, após isso refatorei a funcao SaveUser para usar a funcao QueryRow para simplificar a leitura do id. 